### PR TITLE
Add option to disable hardware monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ CUSTOM_MASKDICTIONARY = "maskdict.txt"  # optional but both are required (wordli
 CUSTOM_MASK = "?d?d?d?d?d"  # optional but both are required (mask must be in hashcat format)
 CRACKER_ID = str(uuid.uuid4())  # Generate a unique cracker ID
 USERKEY = "YOUR-USER-KEY"  # Add this variable
+DISABLE_HWMON = False  # Set to True to disable hardware monitoring
 ````
 
 **Note:** Ensure `hashcat.exe` is in the same folder as the Python file on Windows, or Hashcat is usable as a command in that directory for every OS.
+**Another Note: Disabling hardware monitoring may damage the GPU you're using hashcat on, as it essentially overrides any settings set by graphic drivers to prevent damage.**
 
 ## pwnagotchi plugin pwncrack.py 🤖
 

--- a/help_crack.py
+++ b/help_crack.py
@@ -15,7 +15,7 @@ CUSTOM_MASKDICTIONARY = "maskdict.txt"  # optional but both are required (wordli
 CUSTOM_MASK = "?d?d?d?d?d"  # optional but both are required (mask must be in hashcat format)
 CRACKER_ID = str(uuid.uuid4())  # Generate a unique cracker ID
 USERKEY = "YOUR-USER-KEY"  # Add this variable
-DISABLE_HWMON = True  # Set to True to disable hardware monitoring
+DISABLE_HWMON = False  # Set to True to disable hardware monitoring
 
 class TerminalColors:
     ORANGE = '\033[33m'

--- a/help_crack.py
+++ b/help_crack.py
@@ -15,6 +15,7 @@ CUSTOM_MASKDICTIONARY = "maskdict.txt"  # optional but both are required (wordli
 CUSTOM_MASK = "?d?d?d?d?d"  # optional but both are required (mask must be in hashcat format)
 CRACKER_ID = str(uuid.uuid4())  # Generate a unique cracker ID
 USERKEY = "YOUR-USER-KEY"  # Add this variable
+DISABLE_HWMON = True  # Set to True to disable hardware monitoring
 
 class TerminalColors:
     ORANGE = '\033[33m'
@@ -134,6 +135,9 @@ def crack_file(file_name):
         WORDLIST
     ]
     
+    if DISABLE_HWMON:
+        command.append("--hwmon-disable")
+    
     second_file_name = None
     
     try:
@@ -179,6 +183,8 @@ def crack_file(file_name):
                 CUSTOM_WORDLIST,
                 "-r", CUSTOM_RULES
             ]
+            if DISABLE_HWMON:
+                command.append("--hwmon-disable")
             with open(log_file, 'w') as log:
                 process = subprocess.Popen(command, stdout=log, stderr=log, text=True)
             
@@ -212,6 +218,8 @@ def crack_file(file_name):
                 CUSTOM_MASKDICTIONARY,
                 CUSTOM_MASK
             ]
+            if DISABLE_HWMON:
+                command.append("--hwmon-disable")
             with open(log_file, 'w') as log:
                 process = subprocess.Popen(command, stdout=log, stderr=log, text=True)
             


### PR DESCRIPTION
For context I did face this on the logs

```md
Driver temperature threshold met on GPU #1. Expect reduced performance.
```

This update is essentially a bypass for this if it ever were to happen to anyone, it seems to be controlled by drivers but hashcat can override it. 